### PR TITLE
Make each vehicle publish to its own topic

### DIFF
--- a/nodes/all_in_one_publisher.py
+++ b/nodes/all_in_one_publisher.py
@@ -52,10 +52,10 @@ class ROSMessagePublisher:
         self.pub_dict = {}
 
 
-
-# store publisher object as value in a dic given a vehicle namespace, message-type specific dictionary, topic name and message class
-def create_publisher(veh_ns, pub_dic, topic_name, ms_class):
-    pub_dic[veh_ns] = rospy.Publisher(topic_name, ms_class, queue_size=10)
+    # store publisher object as value in a dict given topic name and message class
+    def create_publisher(self, topic_name, ms_class):
+        self.pub_dict[topic_name] = rospy.Publisher(topic_name, ms_class, queue_size=10)
+        print("here")
 
 def create_pipe(pipe_name):
     pipe_path = f"\\\\.\\pipe\\{pipe_name}"

--- a/nodes/all_in_one_publisher.py
+++ b/nodes/all_in_one_publisher.py
@@ -45,12 +45,12 @@ from tf2_msgs.msg import TFMessage
 
 
 class ROSMessagePublisher:
+    def __init__(self):
+        # instantiate an empty dictionary
+        # it's used for storing an unique topic_name and publisher as key-value pairs in dict as class variable so that the publisher won't be created repeatedly
+        # NOTE: topic_name = <namespace>/<topic_name> so it's always unique
+        self.pub_dict = {}
 
-    # creat esome class variables shared across all instances of the class
-    # instantiate an empty dictionary
-    # it's used for storing an unique topic_name and publisher as key-value pairs in dict as class variable so that the publisher won't be created repeatedly
-    # NOTE: topic_name = <namespace>/<topic_name> so it's always unique
-    pub_dict = {}
 
 
 # store publisher object as value in a dic given a vehicle namespace, message-type specific dictionary, topic name and message class

--- a/nodes/all_in_one_publisher.py
+++ b/nodes/all_in_one_publisher.py
@@ -49,24 +49,27 @@ class ROSMessagePublisher:
     # sim time message initialization 
     pub_sim = rospy.Publisher('clock', Clock, queue_size=10)  
 
-    # odom messages initialization
-    pub_odom = rospy.Publisher('odom', Odometry, queue_size=10)
-
-    # laser scan messages initialization
-    pub_laser = rospy.Publisher('scan', LaserScan, queue_size=10)  
-
     # instantiate object of imu publisher
-    pub_imu = rospy.Publisher('imu', Imu, queue_size=10)  
+    pub_imu = rospy.Publisher('imu', Imu, queue_size=10)
 
     # instantiate object of tf publisher
-    pub_tf = rospy.Publisher('tf', TFMessage, queue_size=10)  
+    pub_tf = rospy.Publisher('tf', TFMessage, queue_size=10)
 
-    def laser_scan_pub(self, scan):
-        for count, value in enumerate(scan.ranges):
-            if float(value) == 1000:
-                scan.ranges[count] = float('Inf')
-        self.pub_laser.publish(scan)
+    # instantiate object of float publisher
+    pub_float64 = rospy.Publisher('fs_output', Float64MultiArray, queue_size=10)
 
+    # instantiate empty dictionary to store vehicle_ns-odom_publisher pairs
+    pub_odom_dic = {}
+
+    # instantiate empty dictionary to store vehicle_ns-scan_publisher pairs
+    pub_scan_dic = {}
+
+    # instantiate empty dictionary to store vehicle_ns-imu_publisher pairs
+    pub_imu_dic = {}
+
+# store publisher object as value in a dic given a vehicle namespace, message-type specific dictionary, topic name and message class
+def create_publisher(veh_ns, pub_dic, topic_name, ms_class):
+    pub_dic[veh_ns] = rospy.Publisher(topic_name, ms_class, queue_size=10)
 
 def create_pipe(pipe_name):
     pipe_path = f"\\\\.\\pipe\\{pipe_name}"
@@ -124,17 +127,32 @@ if __name__ == '__main__':
                 sim_time_msg = json_message_converter.convert_json_to_ros_message('rosgraph_msgs/Clock', msg_list[1])
                 object_class.pub_sim.publish(sim_time_msg)
 
-            elif msg_list[0] == "nav_msgs/Odometry":
-                odom_msg = json_message_converter.convert_json_to_ros_message('nav_msgs/Odometry', msg_list[1])
-                object_class.pub_odom.publish(odom_msg)
+            elif msg_list[1] == "nav_msgs/Odometry":
+                veh_ns = msg_list[0]
+                if veh_ns not in object_class.pub_odom_dic:
+                    topic_name = veh_ns + "/odom"
+                    create_publisher(veh_ns, object_class.pub_odom_dic, topic_name, Odometry)
+                odom_msg = json_message_converter.convert_json_to_ros_message('nav_msgs/Odometry', msg_list[2])
+                object_class.pub_odom_dic[veh_ns].publish(odom_msg)
 
-            elif msg_list[0] == "sensor_msgs/LaserScan":
-                scan_msg = json_message_converter.convert_json_to_ros_message('sensor_msgs/LaserScan', msg_list[1])
-                object_class.laser_scan_pub(scan_msg)
+            elif msg_list[1] == "sensor_msgs/LaserScan":
+                veh_ns = msg_list[0]
+                if veh_ns not in object_class.pub_scan_dic:
+                    topic_name = veh_ns + "/scan"
+                    create_publisher(veh_ns, object_class.pub_scan_dic, topic_name, LaserScan)
+                scan_msg = json_message_converter.convert_json_to_ros_message('sensor_msgs/LaserScan', msg_list[2])
+                for count, value in enumerate(scan_msg.ranges):
+                    if float(value) == 1000:
+                        scan_msg.ranges[count] = float('Inf')
+                object_class.pub_scan_dic[veh_ns].publish(scan_msg)
                 
-            elif msg_list[0] == "sensor_msgs/Imu":
-                imu_msg = json_message_converter.convert_json_to_ros_message('sensor_msgs/Imu', msg_list[1])
-                object_class.pub_imu.publish(imu_msg)
+            elif msg_list[1] == "sensor_msgs/Imu":
+                veh_ns = msg_list[0]
+                if veh_ns not in object_class.pub_imu_dic:
+                    topic_name = veh_ns + "/imu"
+                    create_publisher(veh_ns, object_class.pub_imu_dic, topic_name, Imu)
+                imu_msg = json_message_converter.convert_json_to_ros_message('sensor_msgs/Imu', msg_list[2])
+                object_class.pub_imu_dic[veh_ns].publish(imu_msg)
 
             elif msg_list[0] == "tf2_msgs/TFMessage":
                 tf_msg = json_message_converter.convert_json_to_ros_message('tf2_msgs/TFMessage', msg_list[1])

--- a/nodes/all_in_one_publisher.py
+++ b/nodes/all_in_one_publisher.py
@@ -109,40 +109,39 @@ if __name__ == '__main__':
             #  convert json data from lua to ros message (data read from the pipe is in bytes: need to convert to string)
 
             msg_list = resp[1].decode("utf-8").split("\n")
-            if msg_list[0] == "rosgraph_msgs/Clock":
-                sim_time_msg = json_message_converter.convert_json_to_ros_message('rosgraph_msgs/Clock', msg_list[1])
-                object_class.pub_sim.publish(sim_time_msg)
+            topic_name = msg_list[0]
+            if msg_list[1] == "rosgraph_msgs/Clock":
+                if msg_list[0] not in object_class.pub_dict:
+                    object_class.create_publisher(topic_name, Clock)
+                sim_time_msg = json_message_converter.convert_json_to_ros_message('rosgraph_msgs/Clock', msg_list[2])
+                object_class.pub_dict[topic_name].publish(sim_time_msg)
 
             elif msg_list[1] == "nav_msgs/Odometry":
-                veh_ns = msg_list[0]
-                if veh_ns not in object_class.pub_odom_dic:
-                    topic_name = veh_ns + "/odom"
-                    create_publisher(veh_ns, object_class.pub_odom_dic, topic_name, Odometry)
+                if msg_list[0] not in object_class.pub_dict:
+                    object_class.create_publisher(topic_name, Odometry)
                 odom_msg = json_message_converter.convert_json_to_ros_message('nav_msgs/Odometry', msg_list[2])
-                object_class.pub_odom_dic[veh_ns].publish(odom_msg)
+                object_class.pub_dict[topic_name].publish(odom_msg)
 
             elif msg_list[1] == "sensor_msgs/LaserScan":
-                veh_ns = msg_list[0]
-                if veh_ns not in object_class.pub_scan_dic:
-                    topic_name = veh_ns + "/scan"
-                    create_publisher(veh_ns, object_class.pub_scan_dic, topic_name, LaserScan)
+                if msg_list[0] not in object_class.pub_dict:
+                    object_class.create_publisher(topic_name, LaserScan)
                 scan_msg = json_message_converter.convert_json_to_ros_message('sensor_msgs/LaserScan', msg_list[2])
                 for count, value in enumerate(scan_msg.ranges):
                     if float(value) == 1000:
                         scan_msg.ranges[count] = float('Inf')
-                object_class.pub_scan_dic[veh_ns].publish(scan_msg)
+                object_class.pub_dict[topic_name].publish(scan_msg)
                 
             elif msg_list[1] == "sensor_msgs/Imu":
-                veh_ns = msg_list[0]
-                if veh_ns not in object_class.pub_imu_dic:
-                    topic_name = veh_ns + "/imu"
-                    create_publisher(veh_ns, object_class.pub_imu_dic, topic_name, Imu)
+                if msg_list[0] not in object_class.pub_dict:
+                    object_class.create_publisher(topic_name, Imu)
                 imu_msg = json_message_converter.convert_json_to_ros_message('sensor_msgs/Imu', msg_list[2])
-                object_class.pub_imu_dic[veh_ns].publish(imu_msg)
+                object_class.pub_dict[topic_name].publish(imu_msg)
 
-            elif msg_list[0] == "tf2_msgs/TFMessage":
-                tf_msg = json_message_converter.convert_json_to_ros_message('tf2_msgs/TFMessage', msg_list[1])
-                object_class.pub_tf.publish(tf_msg)
+            elif msg_list[1] == "tf2_msgs/TFMessage":
+                if msg_list[0] not in object_class.pub_dict:
+                    object_class.create_publisher(topic_name, TFMessage)
+                tf_msg = json_message_converter.convert_json_to_ros_message('tf2_msgs/TFMessage', msg_list[2])
+                object_class.pub_dict[topic_name].publish(tf_msg)
 
 
     except rospy.ROSInterruptException:

--- a/nodes/all_in_one_publisher.py
+++ b/nodes/all_in_one_publisher.py
@@ -43,29 +43,15 @@ from sensor_msgs.msg import Imu
 from tf2_msgs.msg import TFMessage
 
 
+
 class ROSMessagePublisher:
-    # some class variables shared across all instances of the class
 
-    # sim time message initialization 
-    pub_sim = rospy.Publisher('clock', Clock, queue_size=10)  
+    # creat esome class variables shared across all instances of the class
+    # instantiate an empty dictionary
+    # it's used for storing an unique topic_name and publisher as key-value pairs in dict as class variable so that the publisher won't be created repeatedly
+    # NOTE: topic_name = <namespace>/<topic_name> so it's always unique
+    pub_dict = {}
 
-    # instantiate object of imu publisher
-    pub_imu = rospy.Publisher('imu', Imu, queue_size=10)
-
-    # instantiate object of tf publisher
-    pub_tf = rospy.Publisher('tf', TFMessage, queue_size=10)
-
-    # instantiate object of float publisher
-    pub_float64 = rospy.Publisher('fs_output', Float64MultiArray, queue_size=10)
-
-    # instantiate empty dictionary to store vehicle_ns-odom_publisher pairs
-    pub_odom_dic = {}
-
-    # instantiate empty dictionary to store vehicle_ns-scan_publisher pairs
-    pub_scan_dic = {}
-
-    # instantiate empty dictionary to store vehicle_ns-imu_publisher pairs
-    pub_imu_dic = {}
 
 # store publisher object as value in a dic given a vehicle namespace, message-type specific dictionary, topic name and message class
 def create_publisher(veh_ns, pub_dic, topic_name, ms_class):

--- a/nodes/all_in_one_publisher.py
+++ b/nodes/all_in_one_publisher.py
@@ -55,7 +55,6 @@ class ROSMessagePublisher:
     # store publisher object as value in a dict given topic name and message class
     def create_publisher(self, topic_name, ms_class):
         self.pub_dict[topic_name] = rospy.Publisher(topic_name, ms_class, queue_size=10)
-        print("here")
 
 def create_pipe(pipe_name):
     pipe_path = f"\\\\.\\pipe\\{pipe_name}"


### PR DESCRIPTION
Instead of publishing the sensor data of all vehicle on one topic, i.e. `odom`,  `laserscanner` or `imu`, each vehicle now can have its own topic by adding a vehicle namespace to the sensor topics.