### PR TITLE
Switch to directly opened named-pipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,19 +21,6 @@ Clone the repository or download the `.zip` at any location
 git clone https://github.com/tud-cor/fs_mod_ros_windows.git
 ```
 
-#### Creating the symbolic link
-
-In order to exchange data with the Python side of the mod, the script uses a symbolic link to a *named pipe*.
-The symbolic link needs to be created *only once*. Do not create it every time the FarmSim is rebooted.
-
-Open a `cmd` window and run the following command:
-
-```cmd
-mklink "%USERPROFILE%\Documents\My Games\FarmingSimulator2019\mods\modROS\ROS_messages" \\.\pipe\ROS_messages
-```
-
-If you get the message *You do not have sufficient privilege to perform this operation*, right-click the Command Prompt shortcut, and select __Run as administrator__ to start an elevated shell. Then try creating the symbolic link again.
-
 #### Setting up Python 3 `virtualenv`
 
 ```cmd

--- a/nodes/all_in_one_publisher.py
+++ b/nodes/all_in_one_publisher.py
@@ -82,21 +82,10 @@ def create_pipe(pipe_name):
 if __name__ == '__main__':
 
     try:
-        named_pipe_path = os.path.join(os.environ['USERPROFILE'], "Documents/My Games/FarmingSimulator2019/mods/modROS/ROS_messages")
-        # check if a symbolic link to a named pipe has been created
-        if not (os.path.islink(named_pipe_path)):
-            print("Cannot find required symbolic link, has it been created? Please refer to the readme for information.")
-            sys.exit(1)
-        else:
-            print("symbolic link has already been created")
-
-        # wait a bit to ensure that symbolic links have been created
-        time.sleep(1)
-
         object_class = ROSMessagePublisher()
 
         rospy.init_node('ros_publisher', anonymous=True)
-        pipe = create_pipe("ROS_messages")
+        pipe = create_pipe("FS19_modROS_pipe")
         print("waiting for client from FarmSim19")
         win32pipe.ConnectNamedPipe(pipe, None)
         print("got client from game!!")


### PR DESCRIPTION
Instead of requiring the use of a redirected named-pipe.

See https://github.com/tud-cor/FS19_modROS/discussions/54 for a discussion about this -- and linked repositories / discussions.

Not sure what we missed when first looking into this, but glad to be able to remove the redirect-a-named-pipe-using-ntfs-symlinks kludge.
